### PR TITLE
overhaul of pass-grave to make it more secure and unambiguous

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,20 @@
 PROG ?= grave
-PREFIX ?= /usr/local
+PREFIX ?= /usr
 DESTDIR ?=
 LIBDIR ?= $(PREFIX)/lib
 SYSTEM_EXTENSION_DIR ?= $(LIBDIR)/password-store/extensions
-BASHCOMPDIR ?= /etc/bash_completion.d
+BASHCOMPDIR ?= $(PREFIX)/share/bash-completion/completions
 
 all:
 	@echo "pass-$(PROG) is a shell script and does not need compilation, it can be simply executed."
 	@echo ""
 	@echo "To install it try \"make install\" instead."
 	@echo
-	@echo "To run pass $(PROG) one needs to have some tools installed on the system:"
-	@echo "     password store"
+	@echo "To run pass $(PROG), you need to have password-store, tar, and gzip installed on your system"
 
 install:
-	install -d "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/"
-	install -m0755 $(PROG).bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash"
-	install -d "$(DESTDIR)$(BASHCOMPDIR)/"
-	install -m 644 pass-grave.bash.completion  "$(DESTDIR)$(BASHCOMPDIR)/pass-grave"
+	@install -Dm0755 $(PROG).bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash"
+	@install -Dm0644 pass-$(PROG).bash.completion "$(DESTDIR)$(BASHCOMPDIR)/pass-$(PROG)"
 	@echo
 	@echo "pass-$(PROG) is installed successfully"
 	@echo
@@ -25,7 +22,7 @@ install:
 uninstall:
 	rm -vrf \
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash" \
-		"$(DESTDIR)$(BASHCOMPDIR)/pass-grave"
+		"$(DESTDIR)$(BASHCOMPDIR)/pass-$(PROG)"
 
 lint:
 	shellcheck -s bash $(PROG).bash
@@ -35,4 +32,3 @@ test:
 	$(MAKE) -C test
 
 .PHONY: install uninstall lint test
-

--- a/README.md
+++ b/README.md
@@ -1,109 +1,106 @@
 # pass-grave
-An extension for [pass](https://www.passwordstore.org/) (the standard Unix password manager) to easily hide the metadata of the password store
 
-## Motivation
+An extension for [pass](https://www.passwordstore.org/) (the standard Unix password manager) to
+easily hide the metadata of the password store
 
-Why a "grave"?
+## Why should I use pass-grave?
+
+pass, by default, exposes meta-data in the password store. Someone with access to your computer
+might find
+
 ```
-      pass by default shows meta-data in the password store. Someone with access
-      to your computer might find ~/.password-store/email/google/johndoe@gmail.com
-      and conclude you have an account with Google and the account name is
-      "johndoe@gmail.com". The same for your banking information, etc.
-
-      The idea for pass-grave comes from
-      pass-tomb: https://github.com/roddhjav/pass-tomb#readme
-      In order to hide this meta-data you can use pass-tomb to place the
-      password store into a tomb (https://www.dyne.org/software/tomb/).
-      The same you can do with this, pass-grave.
-
-      A "grave" is similar to a tomb but a lot lighter and simpler.
-      With "pass grave close" you place the complete passwordstore
-      into the grave, and close the grave, reducing everything to a single
-      file without any meta-data.
-
-      With "pass grave open" you open the grave, take all the information
-      out of the grave and restore the complete passwordstore to its former
-      state.
-
-      So, typically the first operation of a pass session is to open the grave
-      and the very step is to close the grave.
+~/.password-store/email/google/johndoe@gmail.com
 ```
+
+and conclude you have an account with Google and the account name is "johndoe@gmail.com". The same
+goes for other sensitive information like your bank details.
+
+The idea for pass-grave comes from [pass-tomb](https://github.com/roddhjav/pass-tomb#readme) and
+[tomb](https://www.dyne.org/software/tomb/).
+
+pass-tomb hides meta-data by placing your password store into an encrypted "tomb", which uses
+cryptsetup and LUKS under the hood.
+
+pass-grave is similar to pass-tomb but it relies on gpg to place your password store in an encrypted
+"grave". Since pass also uses gpg, this makes pass-grave much more simple and lighter than
+pass-tomb.
 
 ## Usage
 
+The first step after installing pass-grave should be to execute the following command
+
 ```
-Usage:
-    pass grave open
-        On the first run it creates a directory ".grave" in \$PASSWORD_STORE_DIR.
-        By default this is ~/.password-store/.grave".
-        If the grave directory with a grave exists it will open it and
-        restore the full password store. Once restored the grave will be removed.
-        The grave is represented with the file
-        ~/.password-store/.grave/passwordstore.grave.tar.gz2.gpg.
-        The grave is encrypted with the pass GPG key and hence
-        the content of the grave and all its meta-data is protected and
-        hidden.
-    pass grave close
-        If the grave does not exist, "close" creates a copy of the complete password
-        store by creating a compressed tar-file with extension .tar.bz2 and
-        encrypts it with the pass GPG key.
-        Thereafter the password store is removed leaving only the grave file
-        and other files that hold no meta-data (e.g. extensions, backups, gpg-id).
-    pass grave help
-        Prints this help message.
-    pass grave version
-        Prints the version number.
+$ pass grave close
 ```
 
-## Examples
+This will create a `.grave` folder inside your password store directory and create an encrypted file
+called `passwordstore.grave.tar.gz.gpg`.  This file actually contains all of your password store
+data in its original form. The location of the file will be
 
-### Example 1: Opening the grave
+```
+$PASSWORD_STORE_DIR/.grave/passwordstore.grave.tar.gz.gpg
+```
+
+To restore your password store data from the encrypted "grave", execute
+
 ```
 $ pass grave open
 ```
-This opens the grave at the beginning of a session, 
-extracts and restores the password store from the grave file 
-and then removes the grave file.
 
-### Example 2: Closing the grave
+To see this help message, execute
+
 ```
-$ pass grave close
+$ pass grave help
 ```
-This creates the grave, places the complete password store into it 
-and then removes the password store with its meta-data 
-(except some files holding no meta-data). All meta-data
-is hiden now.
-The grave file is a single compressed and GPG encrypted file.             
-The grave can be found at ```$PASSWORD_STORE_DIR/.grave```
-e.g. ```~/.password-store/.grave/passwordstore.grave.tar.gz2.gpg```.
-            
+
+To check the version of pass-grave, execute
+
+```
+$ pass grave version
+```
+
 ## Installation
 
-For installation download and place this bash script file ```grave.bash``` into
-the passwordstore extension directory specified with ```$PASSWORD_STORE_EXTENSIONS_DIR```.
-By default this is ```~/.password-store/.extensions```.
-```
-$ cp grave.bash ~/.password-store/.extensions
-```
-Give the file execution permissions:
-```
-$ chmod 700 ~/.password-store/.extensions/grave.bash
-```
-Set the variable ```PASSWORD_STORE_ENABLE_EXTENSIONS``` to true to enable extensions.
+Before installing pass-grave or any other pass extension, make sure to enable extension support in
+pass by setting the environment variable `PASSWORD_STORE_ENABLE_EXTENSIONS` to `true` and exporting
+it
+
 ```
 $ export PASSWORD_STORE_ENABLE_EXTENSIONS=true
 ```
-Download and source the bash completion file ```pass-grave.bash.completion``` for bash completion.
+
+Add this command to `~/.bash_profile` or `~/.profile` (depending on your installation) to activate
+this environment variable permanently. You may need to re-login for these changes to take effect.
+
+To install pass-grave using the provided `Makefile` (provided by @celenium), enter the following
+commands
+
 ```
-$ source ~/.password-store/.bash-completions/pass-grave.bash.completion
-```
-Type ```pass grave close``` to create your first grave.
-```
-$ pass grave close
+git clone https://github.com/8go/pass-grave
+cd pass-grave
+sudo make install
 ```
 
-PS: The `Makefile` provided by @celenium can help you in the installation. Type `make install`.
+To install pass-grave manually, place the `grave.bash` file in the password store extensions
+directory usually located at
 
+```
+~/.password-store/.extensions/
+```
+
+and make it executable. This can be done using
+
+```
+$ cp grave.bash ~/.password-store/.extensions/
+$ chmod 700 ~/.password-store/.extensions/grave.bash
+```
+
+Optionally, if you want bash-completion for pass-grave, install the `pass-grave.bash.completion`
+file in an appropriate location
+
+```
+$ cp pass-grave.bash.completion ~/.local/share/bash-completion/completions/pass-grave
+```
 
 ## Idea came from
 
@@ -113,11 +110,12 @@ PS: The `Makefile` provided by @celenium can help you in the installation. Type 
 ## Requirements
 
 - `pass` from [https://www.passwordstore.org/](https://www.passwordstore.org/)
-- `tar` to be installed for zipping and compression.
+- `tar` and `gzip` for zipping and compression
 
 ## Notes
 
-Both files are tiny: 200 lines (script) and 23 lines (autocompletion) respectively. You can check them yourself quickly. No need to trust anyone.
+Both files are tiny: ~200 lines (script) and 23 lines (autocompletion) respectively. You can check
+them yourself quickly. No need to trust anyone.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # pass-grave
 
 An extension for [pass](https://www.passwordstore.org/) (the standard Unix password manager) to
-easily hide the metadata of the password store
+easily hide the metadata of the password store.
+
+[![asciicast](https://asciinema.org/a/435080.svg)](https://asciinema.org/a/435080?autoplay=1)
 
 ## Why should I use pass-grave?
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ pass-tomb.
 
 ## Usage
 
+Before you start using `pass-grave`, we **highly** recommended using `git` to ensure the data
+integrity of your password store. You can also setup a bare git repository in a different location
+on the same device or on a different device and use that as a remote repository to keep a backup of
+your password store. A password store can be initialized as a git repository using
+
+```
+$ pass git init
+```
+
 The first step after installing pass-grave should be to execute the following command
 
 ```

--- a/grave.bash
+++ b/grave.bash
@@ -101,7 +101,7 @@ cmd_grave_version() {
 }
 
 cmd_grave_open() {
-  PASSWORD_STORE_GRAVE_PATH="$PASSWORD_STORE_GRAVE_DIR/${PASSWORD_STORE_GRAVE_BASENAME}.tar.bz2.gpg" # path includes filename
+  PASSWORD_STORE_GRAVE_PATH="$PASSWORD_STORE_GRAVE_DIR/${PASSWORD_STORE_GRAVE_BASENAME}.tar.gz.gpg" # path includes filename
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave directory to $PASSWORD_STORE_GRAVE_DIR"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave file to $PASSWORD_STORE_GRAVE_PATH"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PREFIX"
@@ -118,8 +118,8 @@ cmd_grave_open() {
 
   # file does exist
   mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" >/dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
-  $PASSWORD_STORE_GRAVE_DEBUG && echo $GPG -d "${GPG_OPTS[@]}" "$PASSWORD_STORE_GRAVE_PATH" \| tar xj
-  $GPG -d "${GPG_OPTS[@]}" "$PASSWORD_STORE_GRAVE_PATH" | tar xj || die "Could not decrypt or untar grave $PASSWORD_STORE_GRAVE_PATH. Aborting."
+  $PASSWORD_STORE_GRAVE_DEBUG && echo $GPG -d "${GPG_OPTS[@]}" "$PASSWORD_STORE_GRAVE_PATH" \| tar xz
+  $GPG -d "${GPG_OPTS[@]}" "$PASSWORD_STORE_GRAVE_PATH" | tar xz || die "Could not decrypt or untar grave $PASSWORD_STORE_GRAVE_PATH. Aborting."
   rm -f "$PASSWORD_STORE_GRAVE_PATH" || die "Could not remove grave $PASSWORD_STORE_GRAVE_PATH. Please remove manually. Aborting."
   echo "Recreated password store from grave file \"${PASSWORD_STORE_GRAVE_PATH}\" successfully."
   echo "You can now operate on your password store normally. Use \"grave close\" at the end of session to hide meta-data."
@@ -127,7 +127,7 @@ cmd_grave_open() {
 }
 
 cmd_grave_close() {
-  PASSWORD_STORE_GRAVE_PATH="$PASSWORD_STORE_GRAVE_DIR/${PASSWORD_STORE_GRAVE_BASENAME}.tar.bz2.gpg" # path includes filename
+  PASSWORD_STORE_GRAVE_PATH="$PASSWORD_STORE_GRAVE_DIR/${PASSWORD_STORE_GRAVE_BASENAME}.tar.gz.gpg" # path includes filename
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave directory to $PASSWORD_STORE_GRAVE_DIR"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave file to $PASSWORD_STORE_GRAVE_PATH"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PREFIX"
@@ -146,11 +146,11 @@ cmd_grave_close() {
 
   mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" >/dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
   set_gpg_recipients "$(dirname "$PREFIX")"
-  $PASSWORD_STORE_GRAVE_DEBUG && echo tar --exclude ".gpg-id" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cj . \| $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}"
-  tar --exclude ".gpg-id" --exclude=".grave" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cj . | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}" || die "Creating encrypted grave failed. Aborting." # add v for debugging if need be
+  $PASSWORD_STORE_GRAVE_DEBUG && echo tar --exclude ".gpg-id" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cz . \| $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}"
+  tar --exclude ".gpg-id" --exclude=".grave" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cz . | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}" || die "Creating encrypted grave failed. Aborting." # add v for debugging if need be
   chmod 400 "${PASSWORD_STORE_GRAVE_PATH}" >/dev/null || die "Could not change permissions to read-only on file $PASSWORD_STORE_GRAVE_PATH. Aborting."
-  BZ2SIZE=$(wc -c <"${PASSWORD_STORE_GRAVE_PATH}") # returns size in bytes
-  echo "Created grave file \"${PASSWORD_STORE_GRAVE_PATH}\" of size ${BZ2SIZE} bytes."
+  GZSIZE=$(wc -c <"${PASSWORD_STORE_GRAVE_PATH}") # returns size in bytes
+  echo "Created grave file \"${PASSWORD_STORE_GRAVE_PATH}\" of size ${GZSIZE} bytes."
   find . ! -name '.gpg-id' ! -name '.' ! -name '..' ! -path './.grave' ! -path './.grave/*' ! -path './.extensions' ! -path './.extensions/*' ! -path './.backups' ! -path './.backups/*' ! -path './.bash-completions' ! -path './.bash-completions/*' -delete || die "Removing password store after having created grave failed. Aborting."
   popd >/dev/null || die "Could not change directory. Aborting."
 }

--- a/grave.bash
+++ b/grave.bash
@@ -19,78 +19,81 @@
 VERSION="1.1.1"
 PASSWORD_STORE_GRAVE_DEBUG=false                    # true or false, prints debugging messages
 PASSWORD_STORE_GRAVE_DIR=".grave"                   # default directory is $PASSWORD_STORE_GRAVE_DIR; $PREFIX/$PASSWORD_STORE_GRAVE_DIR
-PASSWORD_STORE_GRAVE_BASENAME="passwordstore.grave" # grave will become passwordstore.grave.tar.gz2.gpg
+PASSWORD_STORE_GRAVE_BASENAME="passwordstore.grave" # grave will become passwordstore.grave.tar.gz.gpg
 TAR=$(command -v tar)
 
 cmd_grave_usage() {
   cat <<-_EOF
-Why a "grave"?
-      pass by default shows meta-data in the password store. Someone with access
-      to your computer might find ~/.password-store/email/google/johndoe@gmail.com
+Why should I use pass-grave?
+      pass, by default, shows meta-data in the password store. Someone with
+      access to your computer might find
+
+      ~/.password-store/email/google/johndoe@gmail.com
+
       and conclude you have an account with Google and the account name is
-      "johndoe@gmail.com". The same for your banking information, etc.
+      "johndoe@gmail.com". The same goes for other sensitive information like
+      your bank details.
 
       The idea for pass-grave comes from
+
       pass-tomb: https://github.com/roddhjav/pass-tomb#readme
-      In order to hide this meta-data you can use pass-tomb to place the
-      password store into a tomb (https://www.dyne.org/software/tomb/).
-      The same you can do with this, pass-grave.
+      tomb:      https://www.dyne.org/software/tomb/
 
-      A "grave" is similar to a tomb but a lot lighter and simpler.
-      With "pass grave close" you place the complete passwordstore
-      into the grave, and close the grave, reducing everything to a single
-      file without any meta-data.
-
-      With "pass grave open" you open the grave, take all the information
-      out of the grave and restore the complete passwordstore to its former
-      state.
-
-      So, typically the first operation of a pass session is to open the grave
-      and the very step is to close the grave.
+      pass-tomb hides meta-data by placing your password store into an
+      encrypted "tomb", which uses cryptsetup and LUKS under the hood.
+      pass-grave is similar to pass-tomb but it relies on gpg to place your
+      password store in an encrypted "grave". Since pass also uses gpg, this
+      makes pass-grave much more simple and lighter than pass-tomb.
 
 Usage:
-    $PROGRAM grave open
-        On the first run it creates a directory ".grave" in \$PREFIX.
-        By default this is ~/.password-store/.grave".
-        If the grave directory with a grave exists it will open it and
-        restore the full password store. Once restored the grave will be removed.
-        The grave is represented with the file
-        ~/.password-store/.grave/passwordstore.grave.tar.gz2.gpg.
-        The grave is encrypted with the pass GPG key and hence
-        the content of the grave and all its meta-data is protected and
-        hidden.
-    $PROGRAM grave close
-        If the grave does not exist, "close" creates a copy of the complete password
-        store by creating a compressed tar-file with extension .tar.bz2 and
-        encrypts it with the pass GPG key.
-        Thereafter the password store is removed leaving only the grave file
-        and other files that hold no meta-data (e.g. extensions, backups, gpg-id).
-    $PROGRAM grave help
-        Prints this help message.
-    $PROGRAM grave version
-        Prints the version number.
+      The first step after installing pass-grave should be to execute the
+      following command
 
-Example: $PROGRAM grave open
-            this opens the grave at the beginning of a session
-            and restores the password store from the grave file and then
-            removes the grave file.
-Example: $PROGRAM grave close
-            this creates a copy of the password store and places it into
-            a single compressed and encrypted file. Thereafter it removes
-            the password store (except some files holding no meta-data)
+      $ pass grave close
 
-For installation place this bash script file "grave.bash" into
-the passwordstore extension directory specified with \$PASSWORD_STORE_EXTENSIONS_DIR.
-By default this is ~/.password-store/.extensions.
-E.g. cp grave.bash ~/.password-store/.extensions
-Give the file execution permissions:
-E.g. chmod 700 ~/.password-store/.extensions/grave.bash
-Set the variable PASSWORD_STORE_ENABLE_EXTENSIONS to true to enable extensions.
-E.g. export PASSWORD_STORE_ENABLE_EXTENSIONS=true
-Source the bash completion file "pass-grave.bash.completion" for bash completion.
-E.g. source ~/.password-store/.bash-completions/pass-grave.bash.completion
-Type "pass grave close" to create your first grave.
-E.g. pass grave close
+      This will create a '.grave' folder inside your password store directory
+      and create an encrypted file called 'passwordstore.grave.tar.gz.gpg'.
+      This file actually contains all of your password store data in its
+      original form. The location of the file will be
+
+      $PREFIX/.grave/passwordstore.grave.tar.gz.gpg
+
+      To restore your password store data from the encrypted "grave", execute
+      
+      $ pass grave open
+
+      To see this help message, execute
+
+      $ pass grave help
+
+      To check the version of pass-grave, execute
+
+      $ pass grave version
+
+Install:
+      To install pass-grave, place the 'grave.bash' file in the password store
+      extensions directory located at
+
+      $EXTENSIONS
+
+      and make it executable. This can be done using
+
+      $ cp grave.bash $EXTENSIONS
+      $ chmod 700 $EXTENSIONS/grave.bash
+
+      Optionally, if you want bash-completion for pass-grave, install the
+      'pass-grave.bash.completion' file in an appropriate location
+      
+      $ cp pass-grave.bash.completion ~/.local/share/bash-completion/completions/pass-grave
+
+      Finally, to enable extension support in pass, set the environment
+      variable PASSWORD_STORE_ENABLE_EXTENSIONS to true and export it
+
+      $ export PASSWORD_STORE_ENABLE_EXTENSIONS=true
+
+      Add this command to ~/.bash_profile or ~/.profile (depending on your
+      installation) to activate this environment variable permanently. You may
+      need to re-login for these changes to take effect.
 _EOF
   exit 0
 }

--- a/grave.bash
+++ b/grave.bash
@@ -18,7 +18,7 @@
 
 VERSION="1.1.1"
 PASSWORD_STORE_GRAVE_DEBUG=false                    # true or false, prints debugging messages
-PASSWORD_STORE_GRAVE_DIR=".grave"                   # default directory is $PASSWORD_STORE_GRAVE_DIR; $PASSWORD_STORE_DIR/$PASSWORD_STORE_GRAVE_DIR
+PASSWORD_STORE_GRAVE_DIR=".grave"                   # default directory is $PASSWORD_STORE_GRAVE_DIR; $PREFIX/$PASSWORD_STORE_GRAVE_DIR
 PASSWORD_STORE_GRAVE_BASENAME="passwordstore.grave" # grave will become passwordstore.grave.tar.gz2.gpg
 TAR=$(command -v tar)
 
@@ -50,7 +50,7 @@ Why a "grave"?
 
 Usage:
     $PROGRAM grave open
-        On the first run it creates a directory ".grave" in \$PASSWORD_STORE_DIR.
+        On the first run it creates a directory ".grave" in \$PREFIX.
         By default this is ~/.password-store/.grave".
         If the grave directory with a grave exists it will open it and
         restore the full password store. Once restored the grave will be removed.
@@ -104,12 +104,9 @@ cmd_grave_open() {
   PASSWORD_STORE_GRAVE_PATH="$PASSWORD_STORE_GRAVE_DIR/${PASSWORD_STORE_GRAVE_BASENAME}.tar.bz2.gpg" # path includes filename
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave directory to $PASSWORD_STORE_GRAVE_DIR"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave file to $PASSWORD_STORE_GRAVE_PATH"
+  $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PREFIX"
 
-  if [ -z "$PASSWORD_STORE_DIR" ]; then # var is empty
-    PASSWORD_STORE_DIR="${HOME}/.password-store"
-  fi
-  $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PASSWORD_STORE_DIR"
-  pushd "${PASSWORD_STORE_DIR}" >/dev/null || die "Could not cd into directory $PASSWORD_STORE_DIR. Aborting."
+  pushd "$PREFIX" >/dev/null || die "Could not cd into directory $PREFIX. Aborting."
 
   # does the grave already exist?
   [[ ! -f "$PASSWORD_STORE_GRAVE_PATH" ]] && {
@@ -133,12 +130,9 @@ cmd_grave_close() {
   PASSWORD_STORE_GRAVE_PATH="$PASSWORD_STORE_GRAVE_DIR/${PASSWORD_STORE_GRAVE_BASENAME}.tar.bz2.gpg" # path includes filename
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave directory to $PASSWORD_STORE_GRAVE_DIR"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave file to $PASSWORD_STORE_GRAVE_PATH"
+  $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PREFIX"
 
-  if [ -z "$PASSWORD_STORE_DIR" ]; then # var is empty
-    PASSWORD_STORE_DIR="${HOME}/.password-store"
-  fi
-  $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PASSWORD_STORE_DIR"
-  pushd "${PASSWORD_STORE_DIR}" >/dev/null || die "Could not cd into directory $PASSWORD_STORE_DIR. Aborting."
+  pushd "$PREFIX" >/dev/null || die "Could not cd into directory $PREFIX. Aborting."
 
   # does the grave already exist?
   [[ -f "$PASSWORD_STORE_GRAVE_PATH" ]] && {
@@ -151,7 +145,7 @@ cmd_grave_close() {
   }
 
   mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" >/dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
-  set_gpg_recipients "$(dirname "$PASSWORD_STORE_DIR")"
+  set_gpg_recipients "$(dirname "$PREFIX")"
   $PASSWORD_STORE_GRAVE_DEBUG && echo tar --exclude ".gpg-id" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cj . \| $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}"
   tar --exclude ".gpg-id" --exclude=".grave" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cj . | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}" || die "Creating encrypted grave failed. Aborting." # add v for debugging if need be
   chmod 400 "${PASSWORD_STORE_GRAVE_PATH}" >/dev/null || die "Could not change permissions to read-only on file $PASSWORD_STORE_GRAVE_PATH. Aborting."

--- a/grave.bash
+++ b/grave.bash
@@ -23,7 +23,7 @@ PASSWORD_STORE_GRAVE_BASENAME="passwordstore.grave" # grave will become password
 TAR=$(command -v tar)
 
 cmd_grave_usage() {
-  cat <<-_EOF
+  cat <<- _EOF
 Why should I use pass-grave?
       pass, by default, shows meta-data in the password store. Someone with
       access to your computer might find
@@ -109,7 +109,7 @@ cmd_grave_open() {
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave file to $PASSWORD_STORE_GRAVE_PATH"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PREFIX"
 
-  pushd "$PREFIX" >/dev/null || die "Could not cd into directory $PREFIX. Aborting."
+  pushd "$PREFIX" > /dev/null || die "Could not cd into directory $PREFIX. Aborting."
 
   # does the grave already exist?
   [[ ! -f "$PASSWORD_STORE_GRAVE_PATH" ]] && {
@@ -120,13 +120,13 @@ cmd_grave_open() {
   }
 
   # file does exist
-  mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" >/dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
+  mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" > /dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
   $PASSWORD_STORE_GRAVE_DEBUG && echo $GPG -d "${GPG_OPTS[@]}" "$PASSWORD_STORE_GRAVE_PATH" \| tar xz
   $GPG -d "${GPG_OPTS[@]}" "$PASSWORD_STORE_GRAVE_PATH" | tar xz || die "Could not decrypt or untar grave $PASSWORD_STORE_GRAVE_PATH. Aborting."
   rm -f "$PASSWORD_STORE_GRAVE_PATH" || die "Could not remove grave $PASSWORD_STORE_GRAVE_PATH. Please remove manually. Aborting."
   echo "Recreated password store from grave file \"${PASSWORD_STORE_GRAVE_PATH}\" successfully."
   echo "You can now operate on your password store normally. Use \"grave close\" at the end of session to hide meta-data."
-  popd >/dev/null || die "Could not change directory. Aborting."
+  popd > /dev/null || die "Could not change directory. Aborting."
 }
 
 cmd_grave_close() {
@@ -135,7 +135,7 @@ cmd_grave_close() {
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Setting grave file to $PASSWORD_STORE_GRAVE_PATH"
   $PASSWORD_STORE_GRAVE_DEBUG && echo "Password storage directory is $PREFIX"
 
-  pushd "$PREFIX" >/dev/null || die "Could not cd into directory $PREFIX. Aborting."
+  pushd "$PREFIX" > /dev/null || die "Could not cd into directory $PREFIX. Aborting."
 
   # does the grave already exist?
   [[ -f "$PASSWORD_STORE_GRAVE_PATH" ]] && {
@@ -147,15 +147,15 @@ cmd_grave_close() {
     die "Aborting."
   }
 
-  mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" >/dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
+  mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" > /dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
   set_gpg_recipients "$(dirname "$PREFIX")"
   $PASSWORD_STORE_GRAVE_DEBUG && echo tar --exclude ".gpg-id" --exclude=".extensions" --exclude=".backups" -cz . \| $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}"
   tar --exclude ".gpg-id" --exclude=".grave" --exclude=".extensions" --exclude=".backups" -cz . | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}" || die "Creating encrypted grave failed. Aborting." # add v for debugging if need be
-  chmod 400 "${PASSWORD_STORE_GRAVE_PATH}" >/dev/null || die "Could not change permissions to read-only on file $PASSWORD_STORE_GRAVE_PATH. Aborting."
-  GZSIZE=$(wc -c <"${PASSWORD_STORE_GRAVE_PATH}") # returns size in bytes
+  chmod 400 "${PASSWORD_STORE_GRAVE_PATH}" > /dev/null || die "Could not change permissions to read-only on file $PASSWORD_STORE_GRAVE_PATH. Aborting."
+  GZSIZE=$(wc -c < "${PASSWORD_STORE_GRAVE_PATH}") # returns size in bytes
   echo "Created grave file \"${PASSWORD_STORE_GRAVE_PATH}\" of size ${GZSIZE} bytes."
   find . ! -name '.gpg-id' ! -name '.' ! -name '..' ! -path './.grave' ! -path './.grave/*' ! -path './.extensions' ! -path './.extensions/*' ! -path './.backups' ! -path './.backups/*' -delete || die "Removing password store after having created grave failed. Aborting."
-  popd >/dev/null || die "Could not change directory. Aborting."
+  popd > /dev/null || die "Could not change directory. Aborting."
 }
 
 cmd_grave_openclose() {
@@ -173,14 +173,14 @@ cmd_grave_openclose() {
 }
 
 case "$1" in
-help | --help | -h)
-  shift
-  cmd_grave_usage "$@"
-  ;;
-version | --version | -v)
-  shift
-  cmd_grave_version "$@"
-  ;;
-*) cmd_grave_openclose "$@" ;;
+  help | --help | -h)
+    shift
+    cmd_grave_usage "$@"
+    ;;
+  version | --version | -v)
+    shift
+    cmd_grave_version "$@"
+    ;;
+  *) cmd_grave_openclose "$@" ;;
 esac
 exit 0

--- a/grave.bash
+++ b/grave.bash
@@ -146,12 +146,12 @@ cmd_grave_close() {
 
   mkdir -p "${PASSWORD_STORE_GRAVE_DIR}" >/dev/null || die "Could not create directory $PASSWORD_STORE_GRAVE_DIR. Aborting."
   set_gpg_recipients "$(dirname "$PREFIX")"
-  $PASSWORD_STORE_GRAVE_DEBUG && echo tar --exclude ".gpg-id" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cz . \| $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}"
-  tar --exclude ".gpg-id" --exclude=".grave" --exclude=".extensions" --exclude=".backups" --exclude=".bash-completions" -cz . | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}" || die "Creating encrypted grave failed. Aborting." # add v for debugging if need be
+  $PASSWORD_STORE_GRAVE_DEBUG && echo tar --exclude ".gpg-id" --exclude=".extensions" --exclude=".backups" -cz . \| $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}"
+  tar --exclude ".gpg-id" --exclude=".grave" --exclude=".extensions" --exclude=".backups" -cz . | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$PASSWORD_STORE_GRAVE_PATH" "${GPG_OPTS[@]}" || die "Creating encrypted grave failed. Aborting." # add v for debugging if need be
   chmod 400 "${PASSWORD_STORE_GRAVE_PATH}" >/dev/null || die "Could not change permissions to read-only on file $PASSWORD_STORE_GRAVE_PATH. Aborting."
   GZSIZE=$(wc -c <"${PASSWORD_STORE_GRAVE_PATH}") # returns size in bytes
   echo "Created grave file \"${PASSWORD_STORE_GRAVE_PATH}\" of size ${GZSIZE} bytes."
-  find . ! -name '.gpg-id' ! -name '.' ! -name '..' ! -path './.grave' ! -path './.grave/*' ! -path './.extensions' ! -path './.extensions/*' ! -path './.backups' ! -path './.backups/*' ! -path './.bash-completions' ! -path './.bash-completions/*' -delete || die "Removing password store after having created grave failed. Aborting."
+  find . ! -name '.gpg-id' ! -name '.' ! -name '..' ! -path './.grave' ! -path './.grave/*' ! -path './.extensions' ! -path './.extensions/*' ! -path './.backups' ! -path './.backups/*' -delete || die "Removing password store after having created grave failed. Aborting."
   popd >/dev/null || die "Could not change directory. Aborting."
 }
 

--- a/grave.bash
+++ b/grave.bash
@@ -20,7 +20,7 @@ VERSION="1.1.1"
 PASSWORD_STORE_GRAVE_DEBUG=false                    # true or false, prints debugging messages
 PASSWORD_STORE_GRAVE_DIR=".grave"                   # default directory is $PASSWORD_STORE_GRAVE_DIR; $PASSWORD_STORE_DIR/$PASSWORD_STORE_GRAVE_DIR
 PASSWORD_STORE_GRAVE_BASENAME="passwordstore.grave" # grave will become passwordstore.grave.tar.gz2.gpg
-TAR=$(which tar)
+TAR=$(command -v tar)
 
 cmd_grave_usage() {
   cat <<-_EOF

--- a/grave.bash
+++ b/grave.bash
@@ -25,7 +25,7 @@ TAR=$(command -v tar)
 cmd_grave_usage() {
   cat <<- _EOF
 Why should I use pass-grave?
-      pass, by default, shows meta-data in the password store. Someone with
+      pass, by default, exposes meta-data in the password store. Someone with
       access to your computer might find
 
       ~/.password-store/email/google/johndoe@gmail.com

--- a/grave.bash
+++ b/grave.bash
@@ -151,7 +151,7 @@ cmd_grave_close() {
   chmod 400 "${PASSWORD_STORE_GRAVE_PATH}" >/dev/null || die "Could not change permissions to read-only on file $PASSWORD_STORE_GRAVE_PATH. Aborting."
   BZ2SIZE=$(wc -c <"${PASSWORD_STORE_GRAVE_PATH}") # returns size in bytes
   echo "Created grave file \"${PASSWORD_STORE_GRAVE_PATH}\" of size ${BZ2SIZE} bytes."
-  find . ! -name '.gpg-id' ! -name '.' ! -name '..' ! -path './.grave' ! -path './.grave/*' ! -path './.extensions' ! -path './.extensions/*' ! -path './.backups' ! -path './.backups/*' ! -path './.bash-completions' ! -path './.bash-completions/*' -exec rm -rf {} + || die "Removing password store after having created grave failed. Aborting."
+  find . ! -name '.gpg-id' ! -name '.' ! -name '..' ! -path './.grave' ! -path './.grave/*' ! -path './.extensions' ! -path './.extensions/*' ! -path './.backups' ! -path './.backups/*' ! -path './.bash-completions' ! -path './.bash-completions/*' -delete || die "Removing password store after having created grave failed. Aborting."
   popd >/dev/null || die "Could not change directory. Aborting."
 }
 


### PR DESCRIPTION
Please check the expanded commit messages for details on what changes have been made and the reason they were made.

I've also made some cosmetic changes to the help menu in `grave.bash` and in the `README`. Please let me know if you're okay with the changes I've made. I tried to make the language less ambiguous. 